### PR TITLE
Update min Ruby version

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,10 +91,8 @@ class="ruby-identifier">ruby</span><span class="ruby-operator">-</span><span cla
           installed so the extension can be built when it is installed. If you
           are running Windows, then you should install the Windows specific gem
           or install install <a href="https://rubyinstaller.org/add-ons/devkit.html">devkit</a>.</p>
-        <p>ruby-prof requires Ruby 2.5.0 or higher.</p>
+        <p>ruby-prof requires Ruby 2.7.0 or higher.</p>
         <p><strong>!!!WARNING!!!</strong></p>
-        <p>Ruby versions 2.6.1, 2.6.2 and 2.6.3 have a <a href="https://bugs.ruby-lang.org/issues/15911">bug</a>
-          that can cause ruby-prof to return incorrect results. </p>
         <p>Ruby versions 2.7.0 and 2.7.1 have a <a href="https://bugs.ruby-lang.org/issues/17152">bug</a>
           that can cause ruby-prof to return incorrect results.</p>
         <p><br>


### PR DESCRIPTION
- Update min Ruby version from 2.5.0 to 2.7.0 because of https://github.com/ruby-prof/ruby-prof/commit/66296a6332def7ff8f9c8c02836f5653d9653694
- Remove warning about Ruby 2.6.x problems since it's no longer supported